### PR TITLE
Add feature to save and load contact and chat data

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (chat_artifico)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (chat_artifico)" project-jdk-type="Python SDK" />
 </project>

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -1,0 +1,23 @@
+from pickle import dump, load
+
+
+class Data:
+    chats: dict[str, list] = {}
+
+    @classmethod
+    def save_data(cls, file_path: str):
+        with open(file_path, 'wb') as file:
+            dump(cls.chats, file)
+
+    @classmethod
+    def load_data(cls, file_path: str):
+        with open(file_path, 'rb') as file:
+            cls.chats = load(file)
+
+    @classmethod
+    def file_exists(cls, file_path: str) -> bool:
+        try:
+            with open(file_path, 'rb') as file:
+                return True
+        except FileNotFoundError:
+            return False

--- a/src/pages/view_models/account.py
+++ b/src/pages/view_models/account.py
@@ -4,6 +4,7 @@ from src.pages.views.chat import ChatView
 from src.database.database_client import DatabaseClient
 from CTkMessagebox import CTkMessagebox
 from src.sockets.client import set_port
+from src.data.data import Data
 
 
 class AccountViewModel:
@@ -33,6 +34,10 @@ class AccountViewModel:
         if user is None:
             CTkMessagebox(title='Error', message='User name or password is incorrect.', icon='cancel')
             return
+
+        file_name: str = f'{user["port"]}.bin'
+        if Data.file_exists(file_name):
+            Data.load_data(file_name)
 
         self.sign_in_user_name.set('')
         self.sign_in_password.set('')

--- a/src/pages/view_models/chat.py
+++ b/src/pages/view_models/chat.py
@@ -5,6 +5,7 @@ from src.widgets.user_chat_button import UserChatButton
 from src.database.database_client import DatabaseClient
 from CTkMessagebox import CTkMessagebox
 from tkinter import StringVar
+from src.data.data import Data
 
 
 class ChatViewModel:
@@ -43,6 +44,14 @@ class ChatViewModel:
         if client_port == target_port:
             CTkMessagebox(title='Error', message='You cannot add yourself', icon='cancel')
             return
+
+        if user_name in Data.chats:
+            CTkMessagebox(title='Error', message='User already in contacts', icon='cancel')
+            return
+
+        Data.chats[user_name] = []
+        Data.save_data(f'{client_port}.bin')
+        print(Data.chats)
 
         button: UserChatButton = UserChatButton(self.contacts_list_frame, user_name)
         button.configure(command=lambda: self.enter_chat(button.user_name))

--- a/src/pages/view_models/chat.py
+++ b/src/pages/view_models/chat.py
@@ -15,6 +15,8 @@ class ChatViewModel:
         self.frame: CTkScrollableFrame | None = None
         self.contacts_list_frame: CTkScrollableFrame | None = None
         self.chat_boxes: list[CTkButton] = []
+        self.selected_user_name: str | None = None
+        print(Data.chats)
 
     def stop_client(self):
         stop()
@@ -26,6 +28,7 @@ class ChatViewModel:
     def enter_chat(self, user_name: str):
         self.destroy_chat_boxes()
         set_target_port(DatabaseClient.users_collection.find_one({'user_name': user_name})['port'])
+        self.selected_user_name = user_name
         self.contact_name.set(user_name)
 
     def destroy_chat_boxes(self):
@@ -62,6 +65,8 @@ class ChatViewModel:
         message = '\n'.join(wrap(message, 60))
         button = CTkButton(self.frame, width=400, height=50, text=message, font=('Roboto', 15), corner_radius=10)
         self.chat_boxes.append(button)
+        Data.chats[self.selected_user_name].append({'message': message, 'sender': 'client'})
+        Data.save_data(f'{get_port()}.bin')
         button.pack(padx=10, pady=10, anchor='e')
         self.frame._parent_canvas.yview_moveto('1.0')
 
@@ -69,5 +74,14 @@ class ChatViewModel:
         message = '\n'.join(wrap(message, 60))
         button = CTkButton(self.frame, width=400, height=50, text=message, font=('Roboto', 15), corner_radius=10)
         self.chat_boxes.append(button)
+        Data.chats[self.selected_user_name].append({'message': message, 'sender': 'target'})
+        Data.save_data(f'{get_port()}.bin')
         button.pack(padx=10, pady=10, anchor='w')
         self.frame._parent_canvas.yview_moveto('1.0')
+
+    def load_contacts(self):
+        for user_name in Data.chats:
+            button: UserChatButton = UserChatButton(self.contacts_list_frame, user_name)
+            button.configure(command=lambda: self.enter_chat(button.user_name))
+
+            button.pack(pady=(0, 1), expand=True, fill='x')

--- a/src/pages/view_models/chat.py
+++ b/src/pages/view_models/chat.py
@@ -16,7 +16,6 @@ class ChatViewModel:
         self.contacts_list_frame: CTkScrollableFrame | None = None
         self.chat_boxes: list[CTkButton] = []
         self.selected_user_name: str | None = None
-        print(Data.chats)
 
     def stop_client(self):
         stop()
@@ -30,6 +29,14 @@ class ChatViewModel:
         set_target_port(DatabaseClient.users_collection.find_one({'user_name': user_name})['port'])
         self.selected_user_name = user_name
         self.contact_name.set(user_name)
+        self.load_chats()
+
+    def load_chats(self):
+        for message in Data.chats[self.selected_user_name]:
+            if message['sender'] == 'client':
+                self.create_chat_box_client(message['message'], True)
+            else:
+                self.create_chat_box_target(message['message'], True)
 
     def destroy_chat_boxes(self):
         for chat_box in self.chat_boxes:
@@ -54,28 +61,29 @@ class ChatViewModel:
 
         Data.chats[user_name] = []
         Data.save_data(f'{client_port}.bin')
-        print(Data.chats)
 
         button: UserChatButton = UserChatButton(self.contacts_list_frame, user_name)
         button.configure(command=lambda: self.enter_chat(button.user_name))
 
         button.pack(pady=(0, 1), expand=True, fill='x')
 
-    def create_chat_box_client(self, message: str):
+    def create_chat_box_client(self, message: str, for_loading: bool = False):
         message = '\n'.join(wrap(message, 60))
         button = CTkButton(self.frame, width=400, height=50, text=message, font=('Roboto', 15), corner_radius=10)
         self.chat_boxes.append(button)
-        Data.chats[self.selected_user_name].append({'message': message, 'sender': 'client'})
-        Data.save_data(f'{get_port()}.bin')
+        if not for_loading and self.selected_user_name in Data.chats:
+            Data.chats[self.selected_user_name].append({'message': message, 'sender': 'client'})
+            Data.save_data(f'{get_port()}.bin')
         button.pack(padx=10, pady=10, anchor='e')
         self.frame._parent_canvas.yview_moveto('1.0')
 
-    def create_chat_box_target(self, message: str):
+    def create_chat_box_target(self, message: str, for_loading: bool = False):
         message = '\n'.join(wrap(message, 60))
         button = CTkButton(self.frame, width=400, height=50, text=message, font=('Roboto', 15), corner_radius=10)
         self.chat_boxes.append(button)
-        Data.chats[self.selected_user_name].append({'message': message, 'sender': 'target'})
-        Data.save_data(f'{get_port()}.bin')
+        if not for_loading and self.selected_user_name in Data.chats:
+            Data.chats[self.selected_user_name].append({'message': message, 'sender': 'target'})
+            Data.save_data(f'{get_port()}.bin')
         button.pack(padx=10, pady=10, anchor='w')
         self.frame._parent_canvas.yview_moveto('1.0')
 

--- a/src/pages/views/chat.py
+++ b/src/pages/views/chat.py
@@ -1,6 +1,5 @@
 from customtkinter import CTkToplevel, CTkFrame, CTkScrollableFrame, CTkLabel, CTkEntry, CTkButton, CTkTextbox
 from src.pages.view_models.chat import ChatViewModel
-from src.data.data import Data
 
 
 class ChatView(CTkToplevel):
@@ -64,3 +63,5 @@ class ChatView(CTkToplevel):
 
         self.account_view_model.frame = self.messages_frame
         self.account_view_model.contacts_list_frame = self.contacts_list_frame
+
+        self.account_view_model.load_contacts()

--- a/src/pages/views/chat.py
+++ b/src/pages/views/chat.py
@@ -1,5 +1,6 @@
 from customtkinter import CTkToplevel, CTkFrame, CTkScrollableFrame, CTkLabel, CTkEntry, CTkButton, CTkTextbox
 from src.pages.view_models.chat import ChatViewModel
+from src.data.data import Data
 
 
 class ChatView(CTkToplevel):


### PR DESCRIPTION
This pull request adds the feature to save and load the contact and chat data for a user. It adds a class `Data` inside the newly added package `data` which contains a single variable `chats`, a dictionary to save the contact name and the chats list with the contact and functions to save and load that variable from a file and to check if that file exists.

The `Chat` page is then refactored to load the stored contacts as well as the chats from the file. Whenever the user clicks a `UserChatButton`, the corresponding chats are then loaded in the UI for that user.